### PR TITLE
merge 'omar' -> main  read description with all i did 

### DIFF
--- a/src/components/base/BaseInfoCard.vue
+++ b/src/components/base/BaseInfoCard.vue
@@ -5,6 +5,10 @@ defineProps<{
   title?: string;
   userName?: string;
   email?: string;
+  adresse?: string;
+  postNr?: string; 
+  by?: string;
+  land?: string;
   linkText?: string;
   linkUrl?: string;
 }>();
@@ -14,13 +18,20 @@ defineProps<{
   <div class="border-2 border-solid p-5 border-[#6B7280] h-80 w-96 flex flex-col justify-between">
     <div>
       <h1 class="pb-9 text-primary text-3xl font-bold">{{ title }}</h1>
+      
       <div class="text-xl flex flex-col gap-2">
-        <p >{{ userName }}</p>
+        <p >{{ userName || adresse }}</p>
       </div>
+      
       <div class="text-xl flex flex-col gap-2">
-        <p >{{ email }}</p>
+        <p >{{ email || postNr  }} <span>{{ by }}</span></p>
+      </div>
+
+      <div class="text-xl flex flex-col gap-2">
+        <p >{{ land }}</p>
       </div>
     </div>
-    <a :href="linkUrl" class="underline">{{ linkText }}</a>
+
+    <NuxtLink class="underline" v-if="linkUrl" :href="linkUrl"> {{ linkText }}</NuxtLink>
   </div>
 </template> 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -14,8 +14,8 @@ const isMobile = computed(() => width.value < 768);
   <div class="min-h-screen flex flex-col">
 
     <!-- Navigation -->
-    <div>
-      <DesktopNav v-if="!isMobile" />
+    <div class="sticky top-0 z-50 bg-primary shadow-md">
+      <DesktopNav  v-if="!isMobile" />
       <MobileNav v-else />
     </div>
 

--- a/src/middleware/protected.js
+++ b/src/middleware/protected.js
@@ -1,7 +1,8 @@
 import { useAuthStore } from "#imports"
 export default defineNuxtRouteMiddleware(async(to, from) => {
   const auth = useAuthStore();
-
+  await auth.init();
+  
   if (auth.loading) {
     await new Promise(resolve => {
       const stop = watch(

--- a/src/pages/konto/index.vue
+++ b/src/pages/konto/index.vue
@@ -19,7 +19,7 @@ async function logout() {
 <BaseContainer :is-mypage="true">
   <div class="flex justify-between py-8 ">
     <h2 class="text-2xl">Hej {{userName || 'Bruger'}}</h2>
-    <button @click="logout" class="text-2xl underline" >Log out </button>
+    <button @click="logout" class="text-2xl underline" >Log ud </button>
   </div>
   <PartialAccountNavigation class="mb-24"/>
   <div class="flex flex-col gap-6  sm:flex-row sm:justify-between">
@@ -27,9 +27,19 @@ async function logout() {
        :title="'Mine detaljer'"
        :userName="userName"
        :email="auth.user?.email"
+       :text="'hej med dig'"
        linkText="Mine detaljer"
        linkUrl="/konto/profile"
     />
+    <BaseInfoCard
+   :title="'Mine detaljer'"
+   :adresse="'Frydenlund alle nr 35 1tv'"
+   :postNr="'8210'"
+   :by="'Aarhus'"
+   :land="'Denmark'"
+   linkText="Opdater adresse"
+   linkUrl="/konto/profile"
+/>
   </div>
 </BaseContainer>
 </template>

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 
+
 // Define the types for the user and related data
 interface User {
   id: string;
@@ -155,6 +156,9 @@ export const useAuthStore = defineStore('auth', {
         throw createError({ statusCode: 500, message: 'Proxy logout failed' });
       } finally {
         this.clearAuth();
+  
+        const favoriter = useFavoritesStore();  
+        favoriter.clearFavorites();  
         await navigateTo('/');
       }
     },


### PR DESCRIPTION
- adjusted BaseInfoCard.vue to accept more props and adjusted it to add more info to it
- made the footer be keep staying with you when you scroll for desktop + mobile
- fix(auth): await auth.init() in middleware to prevent infinite redirect loop
- reuse BaseInfoCard to show another info, but no data just hard coded values with props
- Fix logout: Clear favorites on logout to reset UI state